### PR TITLE
Convert deployment to OIDC

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,6 +1,7 @@
 name: Deploy to AWS via CDK
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - prod
@@ -8,6 +9,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -15,8 +19,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: "arn:aws:iam::496462056073:role/CoBotStack-GitHubActionsDeployRoleA6F4AD3D-Y7cr5WA9DQVj"
           aws-region: us-west-2
 
       - name: Install Node.js
@@ -29,10 +32,15 @@ jobs:
         with:
           python-version: "3.13"
 
+      - name: Install uv (official script)
+        run: |
+          curl -Ls https://astral.sh/uv/install.sh | sh
+          echo "export PATH=$HOME/.local/bin:$PATH" >> $GITHUB_ENV
+
       - name: Install dependencies
         run: |
           npm install -g aws-cdk
-          pip install -r requirements.txt
+          uv pip install --system .
 
       - name: CDK Deploy
         run: cdk deploy --require-approval never

--- a/deployment/bot_stack.py
+++ b/deployment/bot_stack.py
@@ -11,6 +11,7 @@ from aws_cdk import (
     aws_ecs as ecs,
     aws_ec2 as ec2,
     aws_logs as logs,
+    aws_iam as iam,
 )
 from constructs import Construct
 import os
@@ -55,6 +56,50 @@ class CoBotStack(Stack):
         if add_fargate:
             self._add_fargate_service(audio_bucket, bot_token_secret,
                                       pause_ecs)
+
+        # OIDC provider for GitHub Actions
+        oidc_provider = iam.OpenIdConnectProvider(
+            self,
+            "GitHubOIDCProvider",
+            url="https://token.actions.githubusercontent.com",
+            client_ids=["sts.amazonaws.com"])
+
+        github_policies = [
+            "AmazonEC2FullAccess",
+            "AmazonECS_FullAccess",
+            "AmazonS3FullAccess",
+            "SecretsManagerReadWrite",
+            "CloudWatchLogsFullAccess",
+            "AWSCloudFormationFullAccess",
+            "IAMFullAccess",
+            "AmazonEC2ContainerRegistryPowerUser",
+        ]
+
+        # IAM role for GitHub Actions
+        github_actions_role = iam.Role(
+            self,
+            "GitHubActionsDeployRole",
+            assumed_by=iam.FederatedPrincipal(
+                oidc_provider.open_id_connect_provider_arn,
+                conditions={
+                    "StringLike": {
+                        # Replace with your GitHub org/repo and branch as needed
+                        "token.actions.githubusercontent.com:sub":
+                        "repo:UOAF/sq-co-bot:ref:refs/heads/prod"
+                    }
+                },
+                assume_role_action="sts:AssumeRoleWithWebIdentity"),
+            managed_policies=[
+                iam.ManagedPolicy.from_aws_managed_policy_name(p)
+                for p in github_policies
+            ])
+
+        github_actions_role.add_to_policy(
+            iam.PolicyStatement(
+                actions=["ssm:GetParameter"],
+                resources=[
+                    f"arn:aws:ssm:{self.region}:{self.account}:parameter/cdk-bootstrap/hnb659fds/version"
+                ]))
 
     def _add_fargate_service(self, audio_bucket, bot_token_secret, pause_ecs):
         vpc = ec2.Vpc(self,


### PR DESCRIPTION
This obviates the need for storing AWS credentials in the github repository.